### PR TITLE
Fixed formatting for task list when specifying ID

### DIFF
--- a/task.go
+++ b/task.go
@@ -80,6 +80,7 @@ func (t TaskList) HumanizeById(body io.Reader) string {
 		b.WriteString(task.Host)
 		b.WriteString(" ")
 		b.WriteString(task.Version)
+		b.WriteString("\n")
 		// ports?
 	}
 	title := "ID HOST VERSION\n"


### PR DESCRIPTION
Before

```
➜  marathonctl (master) ✔ marathonctl task list /prom-container-exporter
ID                                                            HOST                                       VERSION
prom-container-exporter.9b90a8c1-d448-11e4-91c7-56847afe9799  host1  2015-03-27T06:15:00.095Zprom-container-exporter.58497f24-e7eb-11e4-9851-56847afe9799  host2  2015-04-09T00:12:27.491Zprom-container-exporter.538196d3-e7eb-11e4-9851-56847afe9799  host3  2015-04-09T00:12:27.491Zprom-container-exporter.360f54b8-e7ec-11e4-9851-56847afe9799  host4  2015-04-09T00:12:27.491Zprom-container-exporter.9af74eed-d448-11e4-91c7-56847afe9799  host5  2015-03-27T06:15:00.095Zprom-container-exporter.933ffc43-de3e-11e4-9498-56847afe9799  host6  2015-03-27T06:15:00.095Z
```

After

```
➜  marathonctl (master) ✔ ./marathonctl task list /prom-container-exporter
ID                                                            HOST                                       VERSION
prom-container-exporter.9b90a8c1-d448-11e4-91c7-56847afe9799  host1  2015-03-27T06:15:00.095Z
prom-container-exporter.58497f24-e7eb-11e4-9851-56847afe9799  host2  2015-04-09T00:12:27.491Z
prom-container-exporter.538196d3-e7eb-11e4-9851-56847afe9799  host3  2015-04-09T00:12:27.491Z
prom-container-exporter.360f54b8-e7ec-11e4-9851-56847afe9799  host4  2015-04-09T00:12:27.491Z
prom-container-exporter.9af74eed-d448-11e4-91c7-56847afe9799  host5  2015-03-27T06:15:00.095Z
prom-container-exporter.933ffc43-de3e-11e4-9498-56847afe9799  host6  2015-03-27T06:15:00.095Z
```
