### PR TITLE
Dockerfile using golang:onbuild

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM golang:onbuild
+
+ENTRYPOINT ["app"]
+CMD []

--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ go get github.com/shoenig/marathonctl
 ```
 - Maybe someday binary downloads will be available
 
+Deployment via Docker
+```
+# Add to ~/.bash_aliases
+alias marathonctl='docker run --net=host shoenig/marathonctl:latest'
+```
+
 ## Usage
 ```
 marathonctl <flags...> [action] <args...>

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ go get github.com/shoenig/marathonctl
 Deployment via Docker
 ```
 # Add to ~/.bash_aliases
-alias marathonctl='docker run --net=host shoenig/marathonctl:latest'
+alias marathonctl='docker run --rm --net=host shoenig/marathonctl:latest'
 ```
 
 ## Usage


### PR DESCRIPTION
Added Dockerfile that uses golang:onbuild to automatically build and package the app binary. This enables very simple deployment and usage e.g. 

```
alias marathonctl='docker run --rm --net=host shoenig/marathonctl:latest'
marathonctl -h http://hostname:8080 marathon ping
```

If this PR be merged then an automatic build with a webhook should be setup on https://registry.hub.docker.com/u/shoenig to automatically build the Docker image whenever the github repo is modified.
