### PR TITLE
Show meaningful error messages when artifact storage is not set up

### DIFF
--- a/artifact.go
+++ b/artifact.go
@@ -88,7 +88,7 @@ func (a ArtifactDelete) Apply(args []string) {
 	request := a.client.DELETE("/v2/artifacts" + url.QueryEscape(args[0]))
 	response, e := a.client.Do(request)
 	Check(e == nil, "failed to delete artifact", e)
-	Check(response.StatusCode == 200, "failed to delete artifact")
+	Check(response.StatusCode == 200, "failed to delete artifact", stringifyResponse(response))
 	defer response.Body.Close()
 
 	fmt.Println(a.format.Format(response.Body, a.Humanize))


### PR DESCRIPTION
Before:

```
$ marathonctl artifact get /app/file.tgz
artifact not found

$ marathonctl artifact upload /app/file.tgz file.tgz
unable to upload file
```

After:

```
$ marathonctl artifact get /app/file.tgz
error downloading artifact {"message":"No storage provider available to load/persist artifacts. Configuration problem?"}

$ marathonctl artifact upload /app/file.tgz file.tgz
unable to upload file {"message":"No storage provider available to load/persist artifacts. Configuration problem?"}
```
