### PR TITLE
feat(client+config): allow unverified tls api endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # marathonctl
 marathonctl is a command line tool for [Marathon](https://mesosphere.github.io/marathon/docs/rest-api.html)
 
-## Install 
+## Install
 ```
 go get github.com/shoenig/marathonctl
 ```
@@ -57,6 +57,7 @@ marathonctl <flags...> [action] <args...>
   -c [config file]
   -h [host]
   -u [user:password] (separated by colon)
+  -k - allow unverified tls connections
   -f [format]
        human  (simplified columns, default)
        json   (json on one line)
@@ -66,7 +67,7 @@ marathonctl <flags...> [action] <args...>
 
 ## Configuration
 - Specify using "-c [file]" or "-h [host:port]"
-    
+
 ### Configuration Properties
 ```
 marathon.host: [hosts] (ex http://node1.indeed.com,http://node2.indeed.com,http://node3.indeed.com)
@@ -104,21 +105,21 @@ $ ./marathonctl -f jsonpp -c /etc/marathonctl.properties marathon leader
 - This example demonstrates the default human readable output
 ````
 $ ./marathonctl -c /etc/marathonctl.properties group list
-GROUPID                                     VERSION                   GROUPS  APPS  
-/                                           2015-04-07T20:29:35.672Z  3       0     
-/websites                                   2015-04-07T20:29:35.672Z  2       0     
-/websites/indeed                            2015-04-07T20:29:35.672Z  1       0     
-/websites/indeed/indeed-pings               2015-04-07T20:29:35.672Z  1       0     
-/websites/indeed/indeed-pings/a.indeed.com  2015-04-07T20:29:35.672Z  0       2     
-/websites/google                            2015-04-07T20:29:35.672Z  2       0     
-/websites/google/news.google.com            2015-04-07T20:29:35.672Z  0       1     
+GROUPID                                     VERSION                   GROUPS  APPS
+/                                           2015-04-07T20:29:35.672Z  3       0
+/websites                                   2015-04-07T20:29:35.672Z  2       0
+/websites/indeed                            2015-04-07T20:29:35.672Z  1       0
+/websites/indeed/indeed-pings               2015-04-07T20:29:35.672Z  1       0
+/websites/indeed/indeed-pings/a.indeed.com  2015-04-07T20:29:35.672Z  0       2
+/websites/google                            2015-04-07T20:29:35.672Z  2       0
+/websites/google/news.google.com            2015-04-07T20:29:35.672Z  0       1
 /websites/google/calendar.google.com        2015-04-07T20:29:35.672Z  0       1
 ````
 #### App Create
 - This example demonstrates creating an app as specified in a json file
 ````
-$ ./marathonctl -c /etc/marathonctl.properties app create sample/ping.google.json 
-APPID                VERSION                   
+$ ./marathonctl -c /etc/marathonctl.properties app create sample/ping.google.json
+APPID                VERSION
 /hoenig/ping-google  2015-04-07T21:41:53.440Z
 ````
 

--- a/client.go
+++ b/client.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
@@ -61,10 +62,23 @@ type Client struct {
 	login  *Login
 }
 
-func NewClient(login *Login) *Client {
+func NewClient(login *Login, insecure bool) *Client {
+	c := http.Client{}
+	if tr := getTransportConfig(insecure); tr != nil {
+		c.Transport = tr
+	}
 	return &Client{
-		client: http.Client{},
+		client: c,
 		login:  login,
+	}
+}
+
+func getTransportConfig(insecure bool) *http.Transport {
+	cfg := &tls.Config{}
+	cfg.InsecureSkipVerify = insecure
+	return &http.Transport{
+		TLSClientConfig:    cfg,
+		DisableCompression: true,
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -11,11 +11,12 @@ import (
 )
 
 // cli arguments override configuration file
-func cliargs() (config, host, login, format string) {
+func cliargs() (config, host, login, format string, insecure bool) {
 	flag.StringVar(&config, "c", "", "config file")
 	flag.StringVar(&host, "h", "", "marathon host with transport and port")
 	flag.StringVar(&login, "u", "", "username and password")
 	flag.StringVar(&format, "f", "", "output format")
+	flag.BoolVar(&insecure, "k", false, "insecure - do not verify cacert")
 	flag.Parse()
 	return
 }
@@ -51,11 +52,11 @@ func configFile() string {
 // todo(someday) read $HOME/.config/marathonctl/config
 // Read -config file
 // Then override with cli args
-func Config() (string, string, string, error) {
-	config, host, login, format := cliargs()
+func Config() (string, string, string, bool, error) {
+	config, host, login, format, insecure := cliargs()
 
 	if host != "" && login != "" {
-		return host, login, format, nil
+		return host, login, format, insecure, nil
 	}
 
 	if config == "" {
@@ -65,7 +66,7 @@ func Config() (string, string, string, error) {
 	if config != "" {
 		h, l, f, e := readConfigfile(config)
 		if e != nil {
-			return "", "", "", e
+			return "", "", "", false, e
 		}
 		if host == "" {
 			host = h
@@ -82,8 +83,8 @@ func Config() (string, string, string, error) {
 	}
 
 	if host == "" {
-		return "", "", "", errors.New("no host info provided")
+		return "", "", "", false, errors.New("no host info provided")
 	}
 
-	return host, login, format, nil
+	return host, login, format, insecure, nil
 }

--- a/main.go
+++ b/main.go
@@ -70,7 +70,7 @@ func Usage() {
 }
 
 func main() {
-	host, login, format, e := Config()
+	host, login, format, insecure, e := Config()
 
 	if e != nil {
 		fmt.Printf("config error: %s\n\n", e)
@@ -79,7 +79,7 @@ func main() {
 
 	f := NewFormatter(format)
 	l := NewLogin(host, login)
-	c := NewClient(l)
+	c := NewClient(l, insecure)
 	app := &Category{
 		actions: map[string]Action{
 			"list":     AppList{c, f},

--- a/main.go
+++ b/main.go
@@ -57,6 +57,7 @@ const Help = `marathonctl <flags...> [action] <args...>
   -c [config file]
   -h [host]
   -u [user:password] (separated by colon)
+  -k - allow unverified tls connections
   -f [format]
        human  (simplified columns, default)
        json   (json on one line)


### PR DESCRIPTION
This change allows a client to connect to a self-signed api server (for private deployments)
