### PR TITLE
fix issue #32 : support for semver semantics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ go:
 
 install:
   - go get github.com/shoenig/config
+  - go get github.com/stretchr/testify
 
 script:
   - go build ./...

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ marathonctl <flags...> [action] <args...>
        json   (json on one line)
        jsonpp (json pretty printed)
        raw    (the exact response from Marathon)
+  -v print git sha1
+  -s print semver version
 ```
 
 ## Configuration

--- a/config.go
+++ b/config.go
@@ -3,93 +3,106 @@
 package main
 
 import (
-	"errors"
 	"flag"
+	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/shoenig/config"
 )
 
+type flags struct {
+	version    bool
+	semver     bool
+	configfile string
+	host       string
+	login      string
+	format     string
+	insecure   bool
+}
+
 // cli arguments override configuration file
-func cliargs() (version bool, config, host, login, format string, insecure bool) {
-	flag.BoolVar(&version, "v", false, "version number (git sha1)")
-	flag.StringVar(&config, "c", "", "config file")
-	flag.StringVar(&host, "h", "", "marathon host with transport and port")
-	flag.StringVar(&login, "u", "", "username and password")
-	flag.StringVar(&format, "f", "", "output format")
-	flag.BoolVar(&insecure, "k", false, "insecure - do not verify cacert")
+func cliargs() flags {
+	var f flags
+	flag.BoolVar(&f.version, "v", false, "display version (git sha1) and exit")
+	flag.BoolVar(&f.semver, "s", false, "display semversion and exit")
+	flag.StringVar(&f.configfile, "c", "", "path to configfile")
+	flag.StringVar(&f.host, "h", "", "override marathon host (with transport and port)")
+	flag.StringVar(&f.login, "u", "", "override username and password")
+	flag.StringVar(&f.format, "f", "", "override output format (raw, json, jsonpp)")
+	flag.BoolVar(&f.insecure, "k", false, "insecure - do not verify certificate authority")
 	flag.Parse()
-	return
+	return f
 }
 
-func readConfigfile(filename string) (host, login, format string, e error) {
-	c, e := config.ReadProperties(filename)
-	if e != nil {
-		return "", "", "", e
+func readConfigfile(filename string) (string, string, string, error) {
+	props, err := config.ReadProperties(filename)
+	if err != nil {
+		return "", "", "", err
 	}
-	h := c.GetStringOr("marathon.host", "")
-	u := c.GetStringOr("marathon.user", "")
-	p := c.GetStringOr("marathon.password", "")
-	f := c.GetStringOr("marathon.format", "")
+	host := props.GetStringOr("marathon.host", "")
+	user := props.GetStringOr("marathon.user", "")
+	pass := props.GetStringOr("marathon.password", "")
+	format := props.GetStringOr("marathon.format", "")
 
-	l := ""
-	if u != "" && p != "" {
-		l = u + ":" + p
+	login := ""
+	if user != "" && pass != "" {
+		login = user + ":" + pass
 	}
 
-	return h, l, f, nil
+	return host, login, format, nil
 }
 
-func configFile() string {
-	configLocations := [2]string{os.Getenv("HOME") + "/.config/marathonctl/config", "/etc/marathonctl"}
-	for _, location := range configLocations {
+func findBestConfigfile() string {
+	locations := [2]string{
+		filepath.Join(os.Getenv("HOME"), ".config", "marathonctl", "config"),
+		filepath.Join("etc", "marathonctl"),
+	}
+
+	for _, location := range locations {
 		if _, err := os.Stat(location); err == nil {
 			return location
 		}
 	}
+
 	return ""
 }
 
-// todo(someday) read $HOME/.config/marathonctl/config
-// Read -config file
-// Then override with cli args
-func Config() (bool, string, string, string, bool, error) {
-	version, config, host, login, format, insecure := cliargs()
+// loadConfig will parse the CLI flags.
+// If --version or --semver are set, no further configuration
+// is read. Otherwise, configuration is read from --configfile as
+// specified, and then overridden with provided CLI flags.
+func loadConfig() (flags, error) {
+	f := cliargs()
 
-	if version {
-		return version, "", "", "", false, nil
+	if f.version || f.semver {
+		return f, nil
 	}
 
-	if host != "" && login != "" {
-		return version, host, login, format, insecure, nil
+	if f.host != "" && f.login != "" {
+		return f, nil
 	}
 
-	if config == "" {
-		config = configFile()
+	if f.configfile == "" {
+		f.configfile = findBestConfigfile()
 	}
 
-	if config != "" {
-		h, l, f, e := readConfigfile(config)
-		if e != nil {
-			return false, "", "", "", false, e
+	if f.configfile != "" {
+		fileHost, fileLogin, fileFormat, err := readConfigfile(f.configfile)
+		if err != nil {
+			return flags{}, fmt.Errorf("failed to read config file: %v", err)
 		}
-		if host == "" {
-			host = h
+
+		if f.host == "" && fileHost != "" {
+			f.host = fileHost
 		}
-		if login == "" {
-			login = l
+		if f.login == "" && fileLogin != "" {
+			f.login = fileLogin
 		}
-		if format == "" {
-			format = f
-			if format == "" {
-				format = "human"
-			}
+		if f.format == "" && fileFormat != "" {
+			f.format = fileFormat
 		}
 	}
 
-	if host == "" {
-		return false, "", "", "", false, errors.New("no host info provided")
-	}
-
-	return version, host, login, format, insecure, nil
+	return f, nil
 }

--- a/config.go
+++ b/config.go
@@ -27,7 +27,7 @@ func cliargs() flags {
 	flag.BoolVar(&f.version, "v", false, "display version (git sha1) and exit")
 	flag.BoolVar(&f.semver, "s", false, "display semversion and exit")
 	flag.StringVar(&f.configfile, "c", "", "path to configfile")
-	flag.StringVar(&f.host, "h", "", "override marathon host (with transport and port)")
+	flag.StringVar(&f.host, "h", "", "override marathon host(s) (with transport and port)")
 	flag.StringVar(&f.login, "u", "", "override username and password")
 	flag.StringVar(&f.format, "f", "", "override output format (raw, json, jsonpp)")
 	flag.BoolVar(&f.insecure, "k", false, "insecure - do not verify certificate authority")
@@ -53,13 +53,15 @@ func readConfigfile(filename string) (string, string, string, error) {
 	return host, login, format, nil
 }
 
-func findBestConfigfile() string {
-	locations := [2]string{
-		filepath.Join(os.Getenv("HOME"), ".config", "marathonctl", "config"),
-		filepath.Join("etc", "marathonctl"),
+func defaultConfigfileLocations() []string {
+	return []string{
+		filepath.Clean(filepath.Join(os.Getenv("HOME"), ".config", "marathonctl", "config")),
+		filepath.FromSlash("/etc/marathonctl"),
 	}
+}
 
-	for _, location := range locations {
+func findBestConfigfile() string {
+	for _, location := range defaultConfigfileLocations() {
 		if _, err := os.Stat(location); err == nil {
 			return location
 		}

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,29 @@
+// Author hoenig
+
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	homeEnv = "HOME"
+)
+
+func Test_defaultConfigfileLocations(t *testing.T) {
+	oldHOME := os.Getenv(homeEnv)
+	defer func() {
+		os.Setenv(homeEnv, oldHOME)
+	}()
+
+	os.Setenv(homeEnv, "/path/to/nowhere")
+
+	locations := defaultConfigfileLocations()
+	require.Equal(t, []string{
+		"/path/to/nowhere/.config/marathonctl/config",
+		"/etc/marathonctl",
+	}, locations)
+}

--- a/version.go
+++ b/version.go
@@ -2,5 +2,8 @@
 
 package main
 
-//go:generate ./version.sh
+//go:generate ./version.sh version
 const Version = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+
+//go:generate ./version.sh semver
+const Semver = "x.x.x"

--- a/version.sh
+++ b/version.sh
@@ -1,7 +1,18 @@
 #!/bin/bash
 
-hash=$(git rev-parse HEAD)
+set -euo pipefail
 
-sed -i s/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/$hash/ version.go
-
-
+case ${1} in
+    version)
+        hash=$(git rev-parse HEAD)
+        sed -i s/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/${hash}/ version.go
+        ;;
+    semver)
+        latest=$(git tag --sort=version:refname | tail -n 1)
+        sed -i s/x.x.x/${latest}/ version.go
+        ;;
+    *)
+        echo "unknown flag: ${1}"
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
A new flag (-s) now prints a semver version number and exits. Script
version.sh has been updated so that go:generate sets a new constant
in version.go to the most recent semver value.

For now, semantic version should be incremented manually by creating
git tags.