### PR TITLE
Force application destruction

### DIFF
--- a/app.go
+++ b/app.go
@@ -283,7 +283,7 @@ type AppDestroy struct {
 
 func (a AppDestroy) Apply(args []string) {
 	Check(len(args) == 1, "must specify id")
-	path := "/v2/apps/" + url.QueryEscape(args[0])
+	path := "/v2/apps/" + url.QueryEscape(args[0]) + "?force=true"
 	request := a.client.DELETE(path)
 	response, e := a.client.Do(request)
 	Check(e == nil, "destroy app failed", e)


### PR DESCRIPTION
Solves #37 , I did not make it configurable in the sake of consistency with other commands using `?force=true`.

See /v2/apps/{app_id} DELETE, `force` query parameter and 409 response:
http://mesosphere.github.io/marathon/api-console/index.html
