### PR TITLE
fix minor goreport issues

### DIFF
--- a/app.go
+++ b/app.go
@@ -144,7 +144,7 @@ type AppCreate struct {
 }
 
 func (a AppCreate) Apply(args []string) {
-	Check(len(args) == 1, "must specifiy 1 jsonfile")
+	Check(len(args) == 1, "must specify 1 jsonfile")
 	f, e := os.Open(args[0])
 	Check(e == nil, "failed to open jsonfile", e)
 	defer f.Close()

--- a/artifact.go
+++ b/artifact.go
@@ -74,6 +74,7 @@ func (a ArtifactGet) Apply(args []string) {
 	defer response.Body.Close()
 
 	b, e := ioutil.ReadAll(response.Body)
+	Check(e == nil, "failed to fetch whole response body", e)
 	os.Stdout.Write(b)
 }
 


### PR DESCRIPTION
marathonctl/artifact.go
[Line 76](https://github.com/shoenig/marathonctl/blob/master/artifact.go#L76): warning: e assigned and not used (ineffassign)

marathonctl/app.go
[Line 147](https://github.com/shoenig/marathonctl/blob/master/app.go#L147): warning: "specifiy" is a misspelling of "specify" (misspell)
